### PR TITLE
Use HTTPS for Google Fonts and Bootstrap CDN

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
     <title>MediaPublic.GitHub.io by mediapublic</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" type="text/css" href="stylesheets/normalize.css" media="screen">
-    <link href='http://fonts.googleapis.com/css?family=Open+Sans:400,700' rel='stylesheet' type='text/css'>
+    <link href='https://fonts.googleapis.com/css?family=Open+Sans:400,700' rel='stylesheet' type='text/css'>
     <link rel="stylesheet" type="text/css" href="stylesheets/stylesheet.css" media="screen">
     <link rel="stylesheet" type="text/css" href="stylesheets/github-light.css" media="screen">
   </head>

--- a/mockups/about.html
+++ b/mockups/about.html
@@ -6,7 +6,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
    
-    <link href='http://fonts.googleapis.com/css?family=Open+Sans' rel='stylesheet' type='text/css'> 
+    <link href='https://fonts.googleapis.com/css?family=Open+Sans' rel='stylesheet' type='text/css'> 
     
     <link rel="stylesheet" href="foundation/css/foundation.css" />
     <link rel="stylesheet" href="css/site.css" />

--- a/mockups/blog.html
+++ b/mockups/blog.html
@@ -6,7 +6,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
    
-    <link href='http://fonts.googleapis.com/css?family=Open+Sans' rel='stylesheet' type='text/css'> 
+    <link href='https://fonts.googleapis.com/css?family=Open+Sans' rel='stylesheet' type='text/css'> 
     
     <link rel="stylesheet" href="foundation/css/foundation.css" />
     <link rel="stylesheet" href="css/site.css" />

--- a/mockups/index.html
+++ b/mockups/index.html
@@ -6,7 +6,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
    
-    <link href='http://fonts.googleapis.com/css?family=Open+Sans' rel='stylesheet' type='text/css'> 
+    <link href='https://fonts.googleapis.com/css?family=Open+Sans' rel='stylesheet' type='text/css'> 
     
     <link rel="stylesheet" href="foundation/css/foundation.css" />
     <link rel="stylesheet" href="css/site.css" />

--- a/mockups/learn.html
+++ b/mockups/learn.html
@@ -6,7 +6,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
    
-    <link href='http://fonts.googleapis.com/css?family=Open+Sans' rel='stylesheet' type='text/css'> 
+    <link href='https://fonts.googleapis.com/css?family=Open+Sans' rel='stylesheet' type='text/css'> 
     
     <link rel="stylesheet" href="foundation/css/foundation.css" />
     <link rel="stylesheet" href="css/site.css" />

--- a/mockups/listen.html
+++ b/mockups/listen.html
@@ -6,7 +6,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
    
-    <link href='http://fonts.googleapis.com/css?family=Open+Sans' rel='stylesheet' type='text/css'> 
+    <link href='https://fonts.googleapis.com/css?family=Open+Sans' rel='stylesheet' type='text/css'> 
     
     <link rel="stylesheet" href="foundation/css/foundation.css" />
     <link rel="stylesheet" href="css/site.css" />

--- a/mockups/people.html
+++ b/mockups/people.html
@@ -6,7 +6,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
    
-    <link href='http://fonts.googleapis.com/css?family=Open+Sans' rel='stylesheet' type='text/css'> 
+    <link href='https://fonts.googleapis.com/css?family=Open+Sans' rel='stylesheet' type='text/css'> 
     
     <link rel="stylesheet" href="foundation/css/foundation.css" />
     <link rel="stylesheet" href="css/site.css" />

--- a/mockups/station.html
+++ b/mockups/station.html
@@ -6,12 +6,12 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
    
-    <link href='http://fonts.googleapis.com/css?family=Open+Sans' rel='stylesheet' type='text/css'> 
+    <link href='https://fonts.googleapis.com/css?family=Open+Sans' rel='stylesheet' type='text/css'> 
     
     <link rel="stylesheet" href="foundation/css/foundation.css" />
     <link rel="stylesheet" href="css/site.css" />
     
-    <link rel="stylesheet" href="http://maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css">
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css">
     
 </head>
 <body>

--- a/mockups/stations.html
+++ b/mockups/stations.html
@@ -6,7 +6,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
    
-    <link href='http://fonts.googleapis.com/css?family=Open+Sans' rel='stylesheet' type='text/css'> 
+    <link href='https://fonts.googleapis.com/css?family=Open+Sans' rel='stylesheet' type='text/css'> 
     
     <link rel="stylesheet" href="foundation/css/foundation.css" />
     <link rel="stylesheet" href="css/site.css" />


### PR DESCRIPTION
This fixes a mixed-content warning when the site is loaded via HTTPS, allowing Google Fonts stylesheet to load: https://mediapublic.github.io/

<img width="1004" alt="screen shot 2015-07-28 at 9 48 53 pm" src="https://cloud.githubusercontent.com/assets/1754187/8948203/801d3094-3572-11e5-9cfb-e3d9f99e1ec7.png">

This has no effect when the site is loaded over plain HTTP.
